### PR TITLE
Remove rails and activejob dependency requirements

### DIFF
--- a/wisper-activejob.gemspec
+++ b/wisper-activejob.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'wisper'
-  # spec.add_dependency 'activejob'
-  spec.add_dependency 'rails', '~>4.2'
+  spec.add_dependency 'rails', '>= 4.0'
 end


### PR DESCRIPTION
These are runtime requirements and we don't really care who provides ActiveJob, as long as it's available.

Resolves #9. Tested in a Rails 4.1 codebase alongside `activejob_backport` and it's looking good.
