### PR TITLE
Fix CI for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem update bundler
 script: rspec spec
 sudo: false
 gemfile:
@@ -6,4 +8,9 @@ gemfile:
   - gemfiles/activejob-5.0
 rvm:
   - rbx-2
-  - 2.2
+  - 2.2.5
+  - 2.3.1
+matrix:
+  exclude:
+    - rvm: rbx-2
+      gemfile: gemfiles/activejob-5.0

--- a/gemfiles/activejob-5.0
+++ b/gemfiles/activejob-5.0
@@ -2,13 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-# use edge Rails until ActiveJob 5 gem released
-gem 'rails', github: 'rails/rails'
-gem 'sprockets-rails', github: "rails/sprockets-rails"
-gem 'sprockets', github: "rails/sprockets"
-gem 'sass-rails', github: "rails/sass-rails"
-gem 'arel', github: "rails/arel"
-gem 'rack', github: "rack/rack"
+gem 'rails', '~> 5.0'
 
 gem 'bundler'
 gem 'rake'


### PR DESCRIPTION
Changes:
1.  Upgraded ruby versions in travis config as Rails 5 requires ruby 2.2.2+
2. Upgraded rails 5 gemfile as Rails 5.0.x if offically released.
